### PR TITLE
fix regression in images due to changes in Easel.js

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -903,7 +903,7 @@ function Block(protoblock, blocks, overrideName) {
 
             var bounds = myContainer.getBounds();
             myContainer.cache(bounds.x, bounds.y, bounds.width, bounds.height);
-            that.value = myContainer.getCacheDataURL();
+	    that.value = myContainer.bitmapCache.getCacheDataURL();
             that.imageBitmap = bitmap;
 
             // Next, scale the bitmap for the thumbnail.


### PR DESCRIPTION
getCacheDataURL method has moved to cache object inside container.