### PR TITLE
Fix several regressions due to mirgration

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -903,7 +903,7 @@ function Block(protoblock, blocks, overrideName) {
 
             var bounds = myContainer.getBounds();
             myContainer.cache(bounds.x, bounds.y, bounds.width, bounds.height);
-            that.value = myContainer.getCacheDataURL();
+	    that.value = myContainer.bitmapCache.getCacheDataURL();
             that.imageBitmap = bitmap;
 
             // Next, scale the bitmap for the thumbnail.

--- a/planet/index.html
+++ b/planet/index.html
@@ -282,7 +282,7 @@
                         </div>
                     </div>
                     <a class="modal-action waves-effect waves-green btn-flat" id="projectviewer-download-file">Download as File</a>
-                    <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat" id="projectviewer-open-mb">Open in Music Blocks</a>
+                    <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat" id="projectviewer-open-mb">Open in Turtle Blocks</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Image loading broke in the migration to Easel 1.0
A label was rendered improperly due to the migration to the new Planet server.