### PR TITLE
Fixed the drag and drop of the help window.

### DIFF
--- a/js/widgets/help.js
+++ b/js/widgets/help.js
@@ -106,9 +106,15 @@ function HelpWidget () {
         // We use this cell as a handle for dragging.
         var dragCell = this._addButton(row, 'grab.svg', ICONSIZE, _('drag'));
         dragCell.style.cursor = 'move';
+        cells = row.getElementsByTagName("td");
 
-        this._dx = dragCell.getBoundingClientRect().left - helpDiv.getBoundingClientRect().left;
-        this._dy = dragCell.getBoundingClientRect().top - helpDiv.getBoundingClientRect().top;
+        //to position the dragged box such that the 
+        //cursor is in the middle of the dragcell
+        //after dropping.
+        this._dx = 0;
+        for(var i = 0; i < 3;i++) this._dx += parseInt(cells[i].style.width.slice(0,2));
+        this._dx +=  parseInt(cells[3].style.width.slice(0,2))/2 
+        this._dy = parseInt(cells[3].style.height.slice(0,2))/2
         this._dragging = false;
         this._target = false;
         this._dragCellHTML = dragCell.innerHTML;


### PR DESCRIPTION
While dragging and dropping the help window,
the top left of the entire window snaps to the cursor.
The expected behavior is that the location, from which
the user drag, snaps to the cursor. Fixed.